### PR TITLE
feat: 添加 emph-cjk 字体用于汉字强调，以增强 CJK 文本显示

### DIFF
--- a/assignment_example.typ
+++ b/assignment_example.typ
@@ -172,6 +172,7 @@
   main: "IBM Plex Sans",
   mono: "IBM Plex Mono",
   cjk: "Noto Serif SC",
+  emph-cjk: "KaiTi",
   math: "IBM Plex Math",
   math-cjk: "Noto Serif SC",
 )

--- a/template.typ
+++ b/template.typ
@@ -4,6 +4,7 @@
   main: "IBM Plex Sans",
   mono: "IBM Plex Mono",
   cjk: "Noto Serif CJK SC",
+  emph-cjk: "KaiTi",
   math: "IBM Plex Math",
   math-cjk: "Noto Serif CJK SC",
 )
@@ -160,6 +161,7 @@
 
   /// 设置字体。
   set text(font: (font.main, font.cjk), size: size, lang: lang, region: region)
+  show emph: text.with(font:(font.main, font.emph-cjk))
   let cjk-markers = regex("[“”‘’．，。、？！：；（）｛｝［］〔〕〖〗《》〈〉「」【】『』─—＿·…\u{30FC}]+")
   show cjk-markers: set text(font: font.cjk)
   show raw: it => {


### PR DESCRIPTION
## 简介
添加汉字强调支持，以增强 CJK 文本显示。

## 用法
`_强调文本_`: 将把 `强调文本` 用 emph-cjk 对应的字体显示

## 设置
如需自定义字体，更改 `default_font` 中的 `emph-cjk` 即可。